### PR TITLE
Add -landscape and -portrait options; add User-Agent

### DIFF
--- a/wallpaper.py
+++ b/wallpaper.py
@@ -121,7 +121,7 @@ def download(dCount):
 
         try:
 
-            print(imurl)
+            print("Downloading:", imurl)
 
             req = urllib2.Request(imurl+".jpg")
             time.sleep(2)
@@ -137,6 +137,7 @@ def download(dCount):
             dCount = dCount + 1
 
         except:
+            print("Download failed for some reason")
             pass
             time.sleep(2)
     print(dCount)

--- a/wallpaper.py
+++ b/wallpaper.py
@@ -158,7 +158,7 @@ def countdownDownload(timerDownload, timerupdate, count):
         timerupdate = stu
         timerDownload = timerDownload - stu
 
-    dCount = download()
+    dCount = download(dCount)
     return dCount
 
 def fetchPreferences():

--- a/wallpaper.py
+++ b/wallpaper.py
@@ -98,7 +98,10 @@ def download(dCount):
     # To avoid 'Too many requests error - 2 second wait and try again in case error
     while(checkVar == dCount):
         try:
-            obj = urllib2.urlopen(url)
+            #obj = urllib2.urlopen(url)
+            opener = urllib2.build_opener()
+            opener.addheaders = [('User-Agent', 'Linux:WallpapersFromReddit:0.1.5 (by tsarjak)')]
+            obj = opener.open(url)
             data = json.load(obj)
             print("Connection Established! Hurray!")
             checkVar += 1

--- a/wallpaper.py
+++ b/wallpaper.py
@@ -22,6 +22,10 @@ def parse_args():
             '--subreddit', type=str, help='Your choice of subreddit to download Images')
         parser.add_argument('-hq', action='store_true',
                             help='If you want to download only high quality photos')
+        parser.add_argument('-landscape', action='store_true',
+                            help='If you want to download only landscape photos')
+        parser.add_argument('-portrait', action='store_true',
+                            help='If you want to download only portrait photos')
         parser.add_argument(
             '-download', action='store_true', help='Download the photos now!')
         args = parser.parse_args()
@@ -32,6 +36,8 @@ def parse_args():
 url = 'http://www.reddit.com/r/wallpaper.json'
 WallpaperCount = 0
 hqchoice = 0
+landscape_only = 0
+portrait_only = 0
 downloadNow = 0
 ops=0
 directory = ""
@@ -54,10 +60,17 @@ def removeUnwantedPhotos(listwallpaper):
         if os.path.getsize(paths) < 102400:
             np = "rm " + paths
             os.system(np)
-        if hqchoice == 1:
+        if hqchoice or landscape_only or portrait_only:
             with Image.open(paths) as im:
                 width, height = im.size
-                if width < 1500 or height < 1500:
+                remove_image = False
+                if hqchoice and width < 1500 or height < 1500:
+                    remove_image = True
+                if landscape_only and height * 1.1 > width:
+                    remove_image = True
+                if portrait_only and width * 1.1 > height:
+                    remove_image = True
+                if remove_image:
                     np = "rm" + paths
                     os.system(np)
 
@@ -211,6 +224,10 @@ if __name__ == '__main__':
         url = 'http://www.reddit.com/r/' + user_choice.subreddit + '.json'
     if user_choice.hq == True:
         hqchoice = 1
+    if user_choice.landscape == True:
+        landscape_only = 1
+    if user_choice.portrait == True:
+        portrait_only = 1
     print(user_choice.download)
     if user_choice.download == True:
         downloadNow = 1


### PR DESCRIPTION
The actual image download is not working for me at the moment (we end up in the `except:` block).

But anyway here are some options which users might like.

Note: As with `-hq`, I think the new `-landscape` and `-portrait` could potentially delete old images in the Wallpapers folder! #24