### PR TITLE
added replace function to image_title; 

### DIFF
--- a/core.py
+++ b/core.py
@@ -68,7 +68,7 @@ class WallpaperDownloader:
                 image_id = content['data']['id']
 
                 # Set image save name
-                img_save_name = '{}_{}.jpg'.format(image_title, image_id)
+                img_save_name = '{}_{}.jpg'.format(image_title.replace("/", "_"), image_id)
                 img_save_name = osp.join(self._preferences['wallpaper_dir'], img_save_name)
 
                 # If we have already downloaded the image, we can skip.


### PR DESCRIPTION
replaces '/' char that is braking on Linux with '_'

On Linux if the image title contains a "/" character it will throw an error: 

"FileNotFoundError: [Errno 2] No such file or directory:"

For example in the image title: 

'Aoraki/Mt Cook-_ow3xme.jpg' - the '/' makes it a directory and throws 'NotFound'

![image](https://user-images.githubusercontent.com/35709452/127905462-659a5f85-9ade-4848-9837-b4a06a973c41.png)

This small change replaces '/' chars with a '_' if it finds any. 
